### PR TITLE
Add the missing SSM Session Manager options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,17 +4,24 @@ resource "aws_ssm_document" "session_manager_prefs" {
   document_format = "JSON"
 
   content = jsonencode({
-    schemaVersion = "1.0",
-    description   = "Document to hold regional settings for Session Manager",
-    sessionType   = "Standard_Stream",
+    schemaVersion = "1.0"
+    description   = "Document to hold regional settings for Session Manager"
+    sessionType   = "Standard_Stream"
     inputs        = {
-      kmsKeyId                    = var.kms_key_id,
-      s3BucketName                = var.s3_bucket_name,
-      s3KeyPrefix                 = var.s3_key_prefix,
-      s3EncryptionEnabled         = var.s3_encryption_enabled,
-      cloudWatchLogGroupName      = var.cloudwatch_log_group_name,
+      kmsKeyId                    = var.kms_key_id
+      s3BucketName                = var.s3_bucket_name
+      s3KeyPrefix                 = var.s3_key_prefix
+      s3EncryptionEnabled         = var.s3_encryption_enabled
+      cloudWatchLogGroupName      = var.cloudwatch_log_group_name
       cloudWatchEncryptionEnabled = var.cloudwatch_encryption_enabled
       cloudWatchStreamingEnabled  = var.cloudwatch_streaming_enabled
+      idleSessionTimeout          = var.idle_session_timeout
+      maxSessionDuration          = var.max_session_duration
+      runAsEnabled                = var.run_as_enabled
+      shellProfile                = {
+        linux   = var.linux_shell_profile
+        windows = var.windows_shell_profile
+      }
     }
   })
 }

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ resource "aws_ssm_document" "session_manager_prefs" {
       s3EncryptionEnabled         = var.s3_encryption_enabled,
       cloudWatchLogGroupName      = var.cloudwatch_log_group_name,
       cloudWatchEncryptionEnabled = var.cloudwatch_encryption_enabled
+      cloudWatchStreamingEnabled  = var.cloudwatch_streaming_enabled
     }
   })
 }

--- a/main.tf
+++ b/main.tf
@@ -3,18 +3,17 @@ resource "aws_ssm_document" "session_manager_prefs" {
   document_type   = "Session"
   document_format = "JSON"
 
-  content = <<DOC
-{
-    "schemaVersion": "1.0",
-    "description": "Document to hold regional settings for Session Manager",
-    "sessionType": "Standard_Stream",
-    "inputs": {
-        "s3BucketName": "${var.s3_bucket_name}",
-        "s3KeyPrefix": "${var.s3_key_prefix}",
-        "s3EncryptionEnabled": ${var.s3_encryption_enabled ? "true" : "false"},
-        "cloudWatchLogGroupName": "${var.cloudwatch_log_group_name}",
-        "cloudWatchEncryptionEnabled": ${var.cloudwatch_encryption_enabled ? "true" : "false"}
+  content = jsonencode({
+    schemaVersion = "1.0",
+    description   = "Document to hold regional settings for Session Manager",
+    sessionType   = "Standard_Stream",
+    inputs        = {
+      kmsKeyId                    = var.kms_key_id,
+      s3BucketName                = var.s3_bucket_name,
+      s3KeyPrefix                 = var.s3_key_prefix,
+      s3EncryptionEnabled         = var.s3_encryption_enabled,
+      cloudWatchLogGroupName      = var.cloudwatch_log_group_name,
+      cloudWatchEncryptionEnabled = var.cloudwatch_encryption_enabled
     }
-}
-DOC
+  })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,3 +35,32 @@ variable "cloudwatch_streaming_enabled" {
   default     = true
   description = "(Optional) Stream session log data to CloudWatch. Defaults to true. If false logs will be uploaded at the end of the session."
 }
+
+variable "idle_session_timeout" {
+  type        = number
+  default     = 20
+  description = "(Optional) Time until a session is closed when left idle."
+}
+
+variable "max_session_duration" {
+  type        = number
+  default     = null
+  description = "(Optional) The longest a session can stay open before it will be closed."
+}
+
+variable "run_as_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "linux_shell_profile" {
+  type        = string
+  default     = ""
+  description = "(Optional) A set of Linux commands to run when a Linux session is started."
+}
+
+variable "windows_shell_profile" {
+  type        = string
+  default     = ""
+  description = "(Optional) A set of Windows commands to run when a Windows session is started."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@ variable "s3_key_prefix" {
 }
 
 variable "s3_encryption_enabled" {
+  type        = bool
   default     = true
   description = "(Optional) Encrypt log data."
 }
@@ -24,6 +25,13 @@ variable "cloudwatch_log_group_name" {
 }
 
 variable "cloudwatch_encryption_enabled" {
+  type        = bool
   default     = true
   description = "(Optional) Encrypt log data."
+}
+
+variable "cloudwatch_streaming_enabled" {
+  type        = bool
+  default     = true
+  description = "(Optional) Stream session log data to CloudWatch. Defaults to true. If false logs will be uploaded at the end of the session."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "kms_key_id" {
+  default     = null
+  description = "(Optional) The KMS key used to to encrypt SSM sessions"
+}
+
 variable "s3_bucket_name" {
   default     = ""
   description = "(Optional) The name of bucket to store session logs. Specifying this enables writing session output to an Amazon S3 bucket."


### PR DESCRIPTION
This MR adds variables for the remaining session manager options. This lets users set things like the KMS key ID that will be used for encrypting sessions, whether to use stream to CloudWatch (recommended, but previously defaulted to uploading at the end of session), the idle and max session duration, shell profiles, and whether run as is enabled.